### PR TITLE
Error en el nombre de la acción patch corregida

### DIFF
--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -17,7 +17,7 @@ export class OrdersController {
     }
 
     @Patch(':id')
-    pathcOrders(@Param('id') id: string, @Body() updateOrder: updateOrderDTO): Promise<UpdateResult>{
+    patchOrders(@Param('id') id: string, @Body() updateOrder: updateOrderDTO): Promise<UpdateResult>{
         return this.orderServcie.updateOrder(id, updateOrder);
     }
 


### PR DESCRIPTION
Error de acción patch corregida en el controller de orders, este anteriormente decía "pathcOrders" y ahora dice "patchOrders"